### PR TITLE
PTR-29 created unit tests for EntityPersister using flyway

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,6 @@
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <version>1.4.200</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.flywaydb</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,14 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>2.1.214</version>
+            <version>1.4.200</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+            <version>7.15.0</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/petros/bibernate/dao/EntityPersister.java
+++ b/src/main/java/com/petros/bibernate/dao/EntityPersister.java
@@ -28,7 +28,10 @@ public class EntityPersister {
 
     public <T> T findOne(Class<T> entityClass, Field field, Object fieldValue) {
         List<T> entities = findAll(entityClass, field, fieldValue);
-        if (entities.size() != 1) {
+        if (entities.size() == 0) {
+            return null;
+        }
+        if (entities.size() > 1) {
             throw new BibernateException("Result must contain exactly one row");
         }
         return entities.get(0);

--- a/src/test/java/com/petros/bibernate/dao/EntityPersisterTest.java
+++ b/src/test/java/com/petros/bibernate/dao/EntityPersisterTest.java
@@ -5,6 +5,7 @@ import com.petros.bibernate.session.model.Product;
 import org.flywaydb.core.Flyway;
 import org.h2.jdbcx.JdbcDataSource;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
@@ -31,8 +32,8 @@ public class EntityPersisterTest {
     }
 
     @Test
+    @DisplayName("Test the findById method with a known entity ID")
     public void testFindById() {
-        // Test the findById method with a known entity ID
         Product product = entityPersister.findById(Product.class, 1L);
 
         assertNotNull(product);
@@ -43,8 +44,8 @@ public class EntityPersisterTest {
     }
 
     @Test
+    @DisplayName("Test the findOne method with a known entity field and value")
     public void testFindOne() throws NoSuchFieldException {
-        // Test the findOne method with a known entity field and value
         Product product = entityPersister.findOne(Product.class, Product.class.getDeclaredField("id"), "2");
 
         assertNotNull(product);
@@ -55,23 +56,23 @@ public class EntityPersisterTest {
     }
 
     @Test
+    @DisplayName("Test the findOne method with non-existed entity")
     public void testFindOneNotFound() throws NoSuchFieldException {
-        // Test the findOne method with non-existed entity
         Product product = entityPersister.findOne(Product.class, Product.class.getDeclaredField("id"), "8");
 
         assertNull(product);
     }
 
     @Test
+    @DisplayName("Test the findOne method with a field that return several products")
     public void testFindOneReturnSeveral() {
-        // Test the findOne method with a field that return several products
         assertThrows(BibernateException.class, () -> entityPersister.findOne(Product.class,
                 Product.class.getDeclaredField("producer"), "Sony"));
     }
 
     @Test
+    @DisplayName("Test the findAll method with a known entity field and value")
     public void testFindAll() throws NoSuchFieldException {
-        // Test the findAll method with a known entity field and value
         List<Product> products = entityPersister
                 .findAll(Product.class, Product.class.getDeclaredField("producer"), "Sony");
         assertEquals(2, products.size());

--- a/src/test/java/com/petros/bibernate/dao/EntityPersisterTest.java
+++ b/src/test/java/com/petros/bibernate/dao/EntityPersisterTest.java
@@ -1,0 +1,79 @@
+package com.petros.bibernate.dao;
+
+import com.petros.bibernate.exception.BibernateException;
+import com.petros.bibernate.session.model.Product;
+import org.flywaydb.core.Flyway;
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class EntityPersisterTest {
+    private EntityPersister entityPersister;
+
+    @BeforeEach
+    public void setUp() {
+        // Create an H2 in-memory database and run the Flyway migration
+        JdbcDataSource dataSource = new JdbcDataSource();
+        dataSource.setUrl("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1");
+        dataSource.setUser("sa");
+        dataSource.setPassword("");
+        Flyway.configure().dataSource(dataSource).locations("classpath:db/migration/product-test-data").load().migrate();
+        // Initialize the EntityPersister with the H2 data source
+        entityPersister = new EntityPersister(dataSource);
+    }
+
+    @Test
+    public void testFindById() {
+        // Test the findById method with a known entity ID
+        Product product = entityPersister.findById(Product.class, 1L);
+
+        assertNotNull(product);
+        assertEquals(1L, product.getId());
+        assertEquals("Play Station", product.getProductName());
+        assertEquals("Sony", product.getProducer());
+        assertEquals(BigDecimal.valueOf(24900, 2), product.getPrice());
+    }
+
+    @Test
+    public void testFindOne() throws NoSuchFieldException {
+        // Test the findOne method with a known entity field and value
+        Product product = entityPersister.findOne(Product.class, Product.class.getDeclaredField("id"), "2");
+
+        assertNotNull(product);
+        assertEquals(2L, product.getId());
+        assertEquals("XBox", product.getProductName());
+        assertEquals("Microsoft", product.getProducer());
+        assertEquals(BigDecimal.valueOf(21500, 2), product.getPrice());
+    }
+
+    @Test
+    public void testFindOneNotFound() throws NoSuchFieldException {
+        // Test the findOne method with non-existed entity
+        Product product = entityPersister.findOne(Product.class, Product.class.getDeclaredField("id"), "8");
+
+        assertNull(product);
+    }
+
+    @Test
+    public void testFindOneReturnSeveral() {
+        // Test the findOne method with a field that return several products
+        assertThrows(BibernateException.class, () -> entityPersister.findOne(Product.class,
+                Product.class.getDeclaredField("producer"), "Sony"));
+    }
+
+    @Test
+    public void testFindAll() throws NoSuchFieldException {
+        // Test the findAll method with a known entity field and value
+        List<Product> products = entityPersister
+                .findAll(Product.class, Product.class.getDeclaredField("producer"), "Sony");
+        assertEquals(2, products.size());
+    }
+}

--- a/src/test/resources/db/migration/product-test-data/R___EntityPersister_test.sql
+++ b/src/test/resources/db/migration/product-test-data/R___EntityPersister_test.sql
@@ -1,0 +1,12 @@
+CREATE TABLE products (
+                          id bigint NOT NULL,
+                          name varchar(255) NOT NULL,
+                          producer varchar(255) NOT NULL,
+                          price decimal(10,2) NOT NULL,
+                          PRIMARY KEY (id)
+);
+
+INSERT INTO products(id, name, producer, price)
+VALUES (1, 'Play Station', 'Sony', 249.00),
+       (2, 'XBox', 'Microsoft', 215.00),
+       (3, 'Play Station Portable', 'Sony', 150.00);


### PR DESCRIPTION
- created unit tests for EntityPersister using Flyway.
- downgraded the version of H2, as there were conflicts with Flyway.
- fixed the logic of the EntityPersister.findOne method. Now, when it doesn't find any records in the database, it returns null instead of throwing an exception (similar to how it works in Hibernate).
- I did not touch or convert the existing tests to Flyway, as Mykola is still working on them.