### PR TITLE
PTR-12 added update method to EntityPersister

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>8.0.23</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
             <version>7.15.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -56,11 +56,6 @@
             <version>1.4.6</version>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>2.0.5</version>
-        </dependency>
-        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>1.4.6</version>

--- a/src/main/java/com/petros/bibernate/dao/EntityPersister.java
+++ b/src/main/java/com/petros/bibernate/dao/EntityPersister.java
@@ -17,25 +17,49 @@ import java.util.stream.Collectors;
 
 import static com.petros.bibernate.util.EntityUtil.getColumnName;
 import static com.petros.bibernate.util.EntityUtil.getIdField;
+import static com.petros.bibernate.util.EntityUtil.getIdValue;
 import static com.petros.bibernate.util.EntityUtil.getInsertableColumns;
 import static com.petros.bibernate.util.EntityUtil.getInsertableValues;
 import static com.petros.bibernate.util.EntityUtil.getTableName;
+import static com.petros.bibernate.util.EntityUtil.getUpdatableColumns;
+import static com.petros.bibernate.util.EntityUtil.getUpdatableValues;
 import static java.lang.Boolean.TRUE;
 
+/**
+ * Provides basic functionality for persisting an entity via JDBC.
+ */
 public class EntityPersister {
     private final DataSource dataSource;
-    private static final String FIND_ENTITY_BY_FIELD_NAME = "select * from %s where %s = ?;";
-    private static final String INSERT_INTO_TABLE_VALUES = "insert into %s(%s) values (%s);";
+    private static final String FIND_ENTITY_BY_FIELD_NAME_TEMPLATE = "select * from %s where %s = ?;";
+    private static final String INSERT_INTO_TABLE_VALUES_TEMPLATE = "insert into %s(%s) values (%s);";
+    private static final String UPDATE_BY_ID_TEMPLATE = "update %s set %s where %s = ?;";
 
     public EntityPersister(DataSource dataSource) {
         this.dataSource = dataSource;
     }
 
+    /**
+     * Retrieves an entity by its identifier.
+     *
+     * @param entityClass the class of the entity to retrieve
+     * @param idValue     the value of the identifier
+     * @param <T>         the type of the entity
+     * @return the entity with the specified identifier, or null if not found
+     */
     public <T> T findById(Class<T> entityClass, Object idValue) {
         Field idField = getIdField(entityClass);
         return findOne(entityClass, idField, idValue);
     }
 
+    /**
+     * Retrieves a single entity based on a field and its value.
+     *
+     * @param entityClass the class of the entity to retrieve
+     * @param field       the field to search by
+     * @param fieldValue  the value of the field to search by
+     * @param <T>         the type of the entity
+     * @return the entity with the specified field value, or null if not found
+     */
     public <T> T findOne(Class<T> entityClass, Field field, Object fieldValue) {
         List<T> entities = findAll(entityClass, field, fieldValue);
         if (entities.size() == 0) {
@@ -47,13 +71,22 @@ public class EntityPersister {
         return entities.get(0);
     }
 
+    /**
+     * Retrieves all entities based on a field and its value.
+     *
+     * @param entityClass the class of the entity to retrieve
+     * @param field       the field to search by
+     * @param fieldValue  the value of the field to search by
+     * @param <T>         the type of the entity
+     * @return a list of entities with the specified field value
+     */
     public <T> List<T> findAll(Class<T> entityClass, Field field, Object fieldValue) {
         List<T> result = new ArrayList<>();
 
         try (var connection = dataSource.getConnection()) {
             String tableName = getTableName(entityClass);
             String columnName = getColumnName(field);
-            String query = String.format(FIND_ENTITY_BY_FIELD_NAME, tableName, columnName);
+            String query = String.format(FIND_ENTITY_BY_FIELD_NAME_TEMPLATE, tableName, columnName);
 
             try (var statement = connection.prepareStatement(query)) {
                 statement.setObject(1, fieldValue);
@@ -68,15 +101,20 @@ public class EntityPersister {
         return result;
     }
 
+    /**
+     * Inserts a new entity into the database.
+     *
+     * @param entity the entity to insert
+     * @param <T>    the type of the entity
+     * @return the inserted entity with the generated identifier
+     **/
     public <T> T insert(T entity) {
         Objects.requireNonNull(entity);
         try (var connection = dataSource.getConnection()) {
             PreparedStatement insertStatement = prepareInsertStatement(entity, connection);
 
             int rowsAffected = insertStatement.executeUpdate();
-            if (rowsAffected != 1) {
-                throw new BibernateException("Failed to insert entity into the database");
-            }
+            throwExceptionIfRowsAffectedNotOne(rowsAffected, "Failed to insert entity into the database");
             setIdFromGeneratedKeys(entity, insertStatement);
             return entity;
 
@@ -85,16 +123,62 @@ public class EntityPersister {
         }
     }
 
+    /**
+     * Updates an existing entity in the database.
+     *
+     * @param entity the entity to update
+     * @param <T>    the type of the entity
+     * @return the updated entity
+     */
+    public <T> T update(T entity) {
+        Objects.requireNonNull(entity);
+        try (var connection = dataSource.getConnection()) {
+            PreparedStatement updateStatement = prepareUpdateStatement(entity, connection);
+
+            int rowsAffected = updateStatement.executeUpdate();
+            throwExceptionIfRowsAffectedNotOne(rowsAffected, "Failed to update entity in the database");
+            return entity;
+
+        } catch (SQLException | IllegalAccessException e) {
+            throw new BibernateException(e);
+        }
+    }
+
+    private static void throwExceptionIfRowsAffectedNotOne(int rowsAffected, String message) {
+        if (rowsAffected != 1) {
+            throw new BibernateException(message);
+        }
+    }
+
     private static <T> PreparedStatement prepareInsertStatement(T entity, Connection connection) throws SQLException {
         String tableName = getTableName(entity.getClass());
         List<String> columns = getInsertableColumns(entity.getClass());
         List<Object> values = getInsertableValues(entity);
         String insertPlaceHolders = getInsertPlaceholders(columns);
-        String insertQuery = String.format(INSERT_INTO_TABLE_VALUES, tableName, String.join(", ", columns),
-                insertPlaceHolders);
+        String insertQuery = String.format(INSERT_INTO_TABLE_VALUES_TEMPLATE, tableName,
+                String.join(", ", columns), insertPlaceHolders);
 
         PreparedStatement statement = connection.prepareStatement(insertQuery, Statement.RETURN_GENERATED_KEYS);
         setPreparedStatementValues(values, statement);
+        return statement;
+    }
+
+    private static <T> PreparedStatement prepareUpdateStatement(T entity, Connection connection) throws SQLException,
+            IllegalAccessException {
+        String tableName = getTableName(entity.getClass());
+        Field idField = getIdField(entity.getClass());
+        Object idValue = getIdValue(entity);
+        if (idValue == null) {
+            throw new BibernateException("ID field is null");
+        }
+        List<String> updateColumns = getUpdatableColumns(entity);
+        List<Object> updateValues = getUpdatableValues(entity);
+
+        String updateQuery = String.format(UPDATE_BY_ID_TEMPLATE, tableName,
+                getUpdatePlaceholders(updateColumns), getColumnName(idField));
+        PreparedStatement statement = connection.prepareStatement(updateQuery);
+        setPreparedStatementValues(updateValues, statement);
+        statement.setObject(updateValues.size() + 1, idValue);
         return statement;
     }
 
@@ -115,10 +199,16 @@ public class EntityPersister {
         }
     }
 
-    private static String getInsertPlaceholders(List<?> insertableValues) {
-        return insertableValues.stream()
+    private static String getInsertPlaceholders(List<?> insertableColumns) {
+        return insertableColumns.stream()
                 .map(f -> "?")
                 .collect(Collectors.joining(","));
+    }
+
+    private static String getUpdatePlaceholders(List<?> updatableColumns) {
+        return updatableColumns.stream()
+                .map(column -> column + " = ?")
+                .collect(Collectors.joining(", "));
     }
 
     private static <T> T mapResultSetToEntity(Class<T> entityClass, ResultSet resultSet) {

--- a/src/main/java/com/petros/bibernate/dao/EntityPersister.java
+++ b/src/main/java/com/petros/bibernate/dao/EntityPersister.java
@@ -1,10 +1,8 @@
 package com.petros.bibernate.dao;
 
 import com.petros.bibernate.exception.BibernateException;
-import com.petros.bibernate.util.EntityUtil;
 import lombok.extern.slf4j.Slf4j;
-import javax.sql.DataSource;
-import java.lang.reflect.Field;
+
 import javax.sql.DataSource;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -52,7 +50,6 @@ public class EntityPersister {
      */
     public <T> T findById(Class<T> entityClass, Object idValue) {
         Field idField = getIdField(entityClass);
-        log.debug("Searching for {} entity by field = {} with id = {}", entityClass.getSimpleName(), idField.getName(), idValue);
         return findOne(entityClass, idField, idValue);
     }
 
@@ -225,15 +222,8 @@ public class EntityPersister {
                 entityField.set(entity, resultSet.getObject(columnName));
             }
             return entity;
-        } catch (InstantiationException e) {
-            throw new BibernateException(e);
-        } catch (IllegalAccessException e) {
-            throw new BibernateException(e);
-        } catch (InvocationTargetException e) {
-            throw new BibernateException(e);
-        } catch (NoSuchMethodException e) {
-            throw new BibernateException(e);
-        } catch (SQLException e) {
+        } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException |
+                 SQLException e) {
             throw new BibernateException(e);
         }
     }

--- a/src/main/java/com/petros/bibernate/util/EntityUtil.java
+++ b/src/main/java/com/petros/bibernate/util/EntityUtil.java
@@ -13,6 +13,9 @@ import java.util.stream.Collectors;
 import static java.lang.String.format;
 import static java.util.Optional.ofNullable;
 
+/**
+ * A utility class for working with database entities.
+ */
 public class EntityUtil {
 
     /**
@@ -53,10 +56,37 @@ public class EntityUtil {
         return idFields.get(0);
     }
 
+    /**
+     * Retrieves the value of the field annotated with {@link Id} from a given entity.
+     *
+     * @param entity the entity from which to retrieve the {@link Id} field value
+     * @return the value of the field marked with {@link Id}
+     * @throws IllegalAccessException if the field is inaccessible
+     */
+    public static Object getIdValue(Object entity) throws IllegalAccessException {
+        var entityClass = entity.getClass();
+        var idField = getIdField(entityClass);
+        idField.setAccessible(true);
+        return idField.get(entity);
+    }
+
+    /**
+     * Determines whether a field is annotated with {@link Id}.
+     *
+     * @param field the field to check
+     * @return true if the field is annotated with {@link Id}, false otherwise
+     */
     public static boolean isIdField(Field field) {
         return field.isAnnotationPresent(Id.class);
     }
 
+    /**
+     * Retrieves the list of columns that are insertable for a given entity class.
+     * Columns annotated with {@link Id} are excluded from the list.
+     *
+     * @param entityClass the entity class for which to retrieve the insertable columns
+     * @return the list of insertable columns
+     */
     public static List<String> getInsertableColumns(Class<?> entityClass) {
         return Arrays.stream(entityClass.getDeclaredFields())
                 .filter(field -> !isIdField(field))
@@ -64,6 +94,13 @@ public class EntityUtil {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * Retrieves the list of insertable values for a given entity.
+     * Values corresponding to fields annotated with {@link Id} are excluded from the list.
+     *
+     * @param entity the entity for which to retrieve the insertable values
+     * @return the list of insertable values
+     */
     public static List<Object> getInsertableValues(Object entity)  {
         return Arrays.stream(entity.getClass().getDeclaredFields())
                 .filter(field -> !isIdField(field))
@@ -71,6 +108,41 @@ public class EntityUtil {
                 .map(field -> {
                     try {
                         return field.get(entity);
+                    } catch (IllegalAccessException e) {
+                        throw new BibernateException(e);
+                    }
+                })
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Retrieves the list of updatable columns for a given entity.
+     * Columns corresponding to fields annotated with {@link Id} are excluded from the list.
+     *
+     * @param entity the entity for which to retrieve the updatable columns
+     * @return the list of updatable columns
+     */
+    public static <T> List<String> getUpdatableColumns(T entity) {
+        return Arrays.stream(entity.getClass().getDeclaredFields())
+                .filter(field -> !isIdField(field))
+                .map(EntityUtil::getColumnName)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Retrieves the list of updatable values for a given entity.
+     * Values corresponding to fields annotated with {@link Id} are excluded from the list.
+     *
+     * @param entity the entity for which to retrieve the updatable values
+     * @return the list of updatable values
+     */
+    public static <T> List<Object> getUpdatableValues(T entity) {
+        return Arrays.stream(entity.getClass().getDeclaredFields())
+                .filter(field -> !isIdField(field))
+                .map(f -> {
+                    try {
+                        f.setAccessible(true);
+                        return f.get(entity);
                     } catch (IllegalAccessException e) {
                         throw new BibernateException(e);
                     }

--- a/src/test/resources/db/migration/product-test-data/R___EntityPersister_test.sql
+++ b/src/test/resources/db/migration/product-test-data/R___EntityPersister_test.sql
@@ -4,6 +4,7 @@ CREATE TABLE products (
                           producer varchar(255) NOT NULL,
                           price decimal(10,2) NOT NULL,
                           PRIMARY KEY (id)
+                      -- todo add data with all SQL types and test it
 );
 
 INSERT INTO products(id, name, producer, price)


### PR DESCRIPTION
- Implemented the update method in the EntityPersister class to support updating entities in the database.
- Added unit tests to ensure the functionality of the implemented methods and validate the behavior of the classes.
- Enhanced the EntityPersister and EntityUtil classes with Javadoc comments for their public methods to provide clear explanations for their functionalities and parameters.
- Added a dependency for the MySQL driver to support database interactions with MySQL.